### PR TITLE
feat: add ios16 scroll bounces properties

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -101,6 +101,11 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *_Nonnull)request
 @property (nonatomic, assign) RNCWebViewPermissionGrantType mediaCapturePermissionGrantType;
 #endif
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000 /* iOS 16 */
+@property (nonatomic, assign) BOOL horizontalBounces;
+@property (nonatomic, assign) BOOL verticalBounces;
+#endif
+
 + (void)setClientAuthenticationCredential:(nullable NSURLCredential*)credential;
 + (void)setCustomCertificatesForHost:(nullable NSDictionary *)certificates;
 - (void)postMessage:(NSString *_Nullable)message;

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -152,6 +152,10 @@ RCTAutoInsetsProtocol>
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 /* iOS 15 */
     _mediaCapturePermissionGrantType = RNCWebViewPermissionGrantType_Prompt;
 #endif
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000
+    _horizontalBounces = YES;
+    _verticalBounces = YES;
+#endif
   }
   
 #if !TARGET_OS_OSX
@@ -446,10 +450,12 @@ RCTAutoInsetsProtocol>
     _webView.scrollView.pagingEnabled = _pagingEnabled;
     //For UIRefreshControl to work correctly, the bounces should always be true
     _webView.scrollView.bounces = _pullToRefreshEnabled || _bounces;
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000
     if (@available(iOS 16, *)) {
-      _webView.scrollView.alwaysBounceVertical = _pullToRefreshEnabled || _bounces;
-      _webView.scrollView.alwaysBounceHorizontal = _pullToRefreshEnabled || _bounces;
+      _webView.scrollView.alwaysBounceVertical = _pullToRefreshEnabled || _verticalBounces;
+      _webView.scrollView.alwaysBounceHorizontal = _pullToRefreshEnabled || _horizontalBounces;
     }
+#endif
     _webView.scrollView.showsHorizontalScrollIndicator = _showsHorizontalScrollIndicator;
     _webView.scrollView.showsVerticalScrollIndicator = _showsVerticalScrollIndicator;
     _webView.scrollView.directionalLockEnabled = _directionalLockEnabled;
@@ -1450,12 +1456,21 @@ didFinishNavigation:(WKNavigation *)navigation
   _bounces = bounces;
   //For UIRefreshControl to work correctly, the bounces should always be true
   _webView.scrollView.bounces = _pullToRefreshEnabled || bounces;
-  if (@available(iOS 16, *)) {
-    _webView.scrollView.alwaysBounceVertical = _pullToRefreshEnabled || _bounces;
-    _webView.scrollView.alwaysBounceHorizontal = _pullToRefreshEnabled || _bounces;
-  }
 }
 #endif // !TARGET_OS_OSX
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000
+- (void)setHorizontalBounces:(BOOL)horizontalBounces
+{
+  _horizontalBounces = horizontalBounces;
+  _webView.scrollView.alwaysBounceHorizontal = _pullToRefreshEnabled || _horizontalBounces;
+}
+- (void)setVerticalBounces:(BOOL)verticalBounces
+{
+  _verticalBounces = verticalBounces;
+  _webView.scrollView.alwaysBounceVertical = _pullToRefreshEnabled || _verticalBounces;
+}
+#endif
 
 - (void)setInjectedJavaScript:(NSString *)source {
   _injectedJavaScript = source;

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -142,6 +142,15 @@ RCT_CUSTOM_VIEW_PROPERTY(bounces, BOOL, RNCWebView) {
   view.bounces = json == nil ? true : [RCTConvert BOOL: json];
 }
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000 /* iOS 16 */
+RCT_CUSTOM_VIEW_PROPERTY(horizontalBounces, BOOL, RNCWebView) {
+  view.horizontalBounces = json == nil ? true : [RCTConvert BOOL: json];
+}
+RCT_CUSTOM_VIEW_PROPERTY(verticalBounces, BOOL, RNCWebView) {
+  view.verticalBounces = json == nil ? true : [RCTConvert BOOL: json];
+}
+#endif
+
 RCT_CUSTOM_VIEW_PROPERTY(useSharedProcessPool, BOOL, RNCWebView) {
   view.useSharedProcessPool = json == nil ? true : [RCTConvert BOOL: json];
 }

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -369,6 +369,8 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   automaticallyAdjustContentInsets?: boolean;
   autoManageStatusBarEnabled?: boolean;
   bounces?: boolean;
+  horizontalBounces?: boolean;
+  verticalBounces?: boolean;
   contentInset?: ContentInsetProp;
   contentInsetAdjustmentBehavior?: ContentInsetAdjustmentBehavior;
   contentMode?: ContentMode;
@@ -430,6 +432,14 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   bounces?: boolean;
+
+  /**
+   * Boolean value that determines whether the web view bounces by direction
+   * when it reaches the edge of the content. The default value is `true`.
+   * @platform ios 16
+   */
+  horizontalBounces?: boolean;
+  verticalBounces?: boolean;
 
   /**
    * A floating-point number that determines how quickly the scroll view


### PR DESCRIPTION
iOS 16에서 스크롤 방향에 따라 bounces 옵션이 따로 적용되는 의도된건지 버그인지 모를 이슈가 있어서 대응코드 추가했습니다.